### PR TITLE
docker-mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+
+persistedOnHost/
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM gradle:jdk11-alpine AS builder
+
+WORKDIR /app
+
+COPY build.gradle /app
+COPY src /app/src
+
+# RUN gradle -g $(pwd)
+RUN gradle build --no-daemon
+
+FROM openjdk:8-jre-buster
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar /app/Application.jar
+COPY src/main/resources/application.conf /app/application.conf
+
+CMD ["java", "-jar", "Application.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# `docker-compose up -d mongodb` OR `docker-compose up -d`
+
+version: '3.8'
+services:
+  mongodb:
+    image: mongo:4.4
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_PASSWORD}
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./persistedOnHost:/data/db #/data/db is mongodb's default location for data
+      - ./docker-entrypoint-initdb.d/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+#      KMG_MONGODB_DATABASE: ${MONGODB_DATABASE}
+      KMG_MONGODB_HOST: mongodb
+      KMG_MONGODB_PORT: "27017"
+      KMG_MONGODB_USERNAME: ${MONGODB_USERNAME}
+      KMG_MONGODB_PASSWORD: ${MONGODB_PASSWORD}

--- a/docker-entrypoint-initdb.d/mongo-init.js
+++ b/docker-entrypoint-initdb.d/mongo-init.js
@@ -1,0 +1,3 @@
+db = db.getSiblingDB('yourBlog');
+
+db.createCollection('article');


### PR DESCRIPTION
docker-compose to spin up database (and app eventually)
Dockerfile is supposed to build the app and run it with gradle (groovy) (no gradle wrapper so far)
assumes you have a .env file with variables in the docker-compose file (right hand side)

data from mongo is persisted in a folder in the project (not tested yet)
